### PR TITLE
Binary search efficiency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${fileDirname}\\main.exe",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerPath": "C:\\mingw64\\bin\\gdb.exe",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "C/C++: g++.exe build active file"
+        }
+
+    ]
+}

--- a/BinarySearch.cpp
+++ b/BinarySearch.cpp
@@ -12,7 +12,7 @@ namespace Algorithms
         auto mid = begin;
 
         while (begin <= end) {
-            size = std::distance(begin, end);
+            size = std::distance(begin, end);   // inefficiency
             mid = begin + (size / 2);
             if (*mid < value) begin = mid + 1;
             else if (*mid > value) end = mid - 1;
@@ -41,21 +41,24 @@ namespace Algorithms
     }
     #endif
 
+    /*
     #if !DETACH
-    template<typename T, typename InputIterator>
-    int BinarySearch::binarySearch(T value, InputIterator first, InputIterator last) {
-        int size;
-        auto mid = first;
-        auto start = first;
+    template<typename T, typename RandomAccessIterator>
+    int BinarySearch::binarySearch(T value, RandomAccessIterator first, RandomAccessIterator last, int size) {
+        // auto start = first;
+        auto checker = first;
+        int mid;
 
-        while (first != last) {
-            size = std::distance(first, last);
-            mid = first + (size / 2);
-            if (*mid < value) first = mid + 1;
-            else if (*mid > value) last = mid - 1;
-            else return std::distance(start, mid);  // Value found
+        while (*first <= *last) {
+            mid = (size - 1) / 2;   // Middle index
+            checker = first + mid;  // Iterator to check the value in the middle
+            if (*checker < value) first += mid + 1;
+            else if (*checker > value) last -= mid - 1;
+            else return mid;  // Value found
+            size = size / 2;
         }        
         return -1;  // Not found
     }
     #endif
+     */
 }

--- a/BinarySearch.h
+++ b/BinarySearch.h
@@ -3,9 +3,11 @@
 // #define USE_ITERS 1
 // #define DETACH 1
 
+/* 
 #if !DETACH
 #include <iterator>
 #endif
+ */
 
 namespace Algorithms
 {
@@ -30,24 +32,27 @@ namespace Algorithms
         template<typename T, class Container>
         static int binarySearch(T value, Container & input);
 
-        #if !DETACH
+        // #if !DETACH
         /**
          * @brief   Find the index of the requested value within a sorted container.
          *          Sorting to be added after getting to sorting algorithms.
          * 
          * @tparam  T the type of data stored in the container (or convertible)
-         * @tparam  InputIterator input iterator type
+         * @tparam  RandomAccessIterator random-access-type iterator
          * @param   value the value to search for
          * @param   first iterator pointing to where the search starts
          * @param   last iterator pointing to where the search ends
+         * @param   size size of the underlying container
          * @pre     input content is of a comparable type convertible to T and sorted in a non-decreasing order
          * @post    return is of type int signifying the index of value or -1 if not found
          *          && input is unchanged
          * @returns int, index of value in the container or -1 if not found
          */
-        template<typename T, typename InputIterator>
-        static int binarySearch(T value, InputIterator first, InputIterator last);
+        /*
+        template<typename T, typename RandomAccessIterator = std::random_access_iterator_tag>
+        static int binarySearch(T value, RandomAccessIterator first, RandomAccessIterator last, int size);
         #endif
+         */
     };
 }
 


### PR DESCRIPTION
Tried to match the logarithmic time efficiency of the `binarySearch` function's conventional implementation with the iterator-based implementation, but ended up scrapping the overload due to it requiring proper generic type constraints and that being a project for after the exam, when I have more time. Also includes the debug configuration file `launch.json` created for debugging.