### PR TITLE
Merge sort

### DIFF
--- a/Algorithms.cpp
+++ b/Algorithms.cpp
@@ -8,3 +8,10 @@ void Algorithms::swap(Container & container, int index1, int index2) {
     container.at(index1) = container.at(index2);
     container.at(index2) = temp;
 }
+
+int Algorithms::intMax() {
+    int i = 0;
+    i = ~i;
+    i = (unsigned int) i >> 1;
+    return i;
+}

--- a/Algorithms.h
+++ b/Algorithms.h
@@ -17,6 +17,14 @@ namespace Algorithms {
      */
     template<class Container>
     void swap(Container & container, int index1, int index2);
+
+    /**
+     * @brief   Returns the maximum value for a variable of type int.
+     *          This is done to avoid external libraries (<climits>).
+     * 
+     * @returns int, maximum value for a variable of type int
+     */
+    int intMax();
 }
 
 #endif // !ALGORITHMS_H

--- a/MergeSort.cpp
+++ b/MergeSort.cpp
@@ -1,0 +1,45 @@
+#include "MergeSort.h"
+
+using namespace Algorithms;
+
+template<class Container>
+void Algorithms::mergeSort(Container & container, int start, int end) {
+    if (start < end) {
+        int middle = (start + end) / 2;
+        mergeSort(container, start, middle);
+        mergeSort(container, middle+1, end);
+        Helper::merge(container, start, middle, end);
+    }
+}
+
+template<class Container>
+void Algorithms::Helper::merge(Container & container, int start, int split, int end) {
+    int sizeA = split - start + 1;
+    int sizeB = end - split;
+    int iA = 0, iB = 0;
+    auto x = container[start];  // Sample container data type
+    typedef decltype(x) T;
+    T A[sizeA+1];
+    T B[sizeB+1];
+    for (int j = start; j <= split; ++j) {
+        A[iA] = container[j];
+        ++iA;
+    }
+    for (int j = split+1; j <= end; ++j) {
+        B[iB] = container[j];
+        ++iB;
+    }
+    A[sizeA] = intMax();
+    B[sizeB] = intMax();
+    iA = 0;
+    iB = 0;
+    for (int j = start; j <= end; ++j) {
+        if (iA < sizeA && A[iA] <= B[iB]) {
+            container[j] = A[iA];
+            ++iA;
+        } else if (iB < sizeB) {
+            container[j] = B[iB];
+            ++iB;
+        }
+    }
+}

--- a/MergeSort.h
+++ b/MergeSort.h
@@ -1,0 +1,30 @@
+#ifndef MERGESORT_H
+#define MERGESORT_H
+
+namespace Algorithms
+{
+    /**
+     * @brief   Sort the container in non-descending order using a merge sort algorithm.
+     *          The algorithm is stable.
+     * 
+     * @tparam  Container the container type
+     * @param   container container to sort, will be modified directly
+     * @pre     container data is modifiable && container data is comparable
+     * @post    container data is sorted in a non-descending order
+     */
+    template<class Container>
+    void mergeSort(Container & container, int start, int end);
+
+    inline namespace Helper {
+        /**
+         * @brief   Helper function for mergeSort.
+         * 
+         * @tparam  Container the container type, must provide functions `size()` and `at()`
+         * @param   container 
+         */
+        template<class Container>
+        void merge(Container & container, int start, int split, int end);
+    }
+}
+
+#endif // !MERGESORT_H


### PR DESCRIPTION
Add merge sort. Also adds a function for fetching the maximum int value to the Algorithms namespace. This is done in order to avoid external libraries.

Merge sort became the first one that could have been simpler to implement with iterators, but as previously stated, my currently limited understanding of C++ templates makes that too much work for these time constraints. I did, however have to use a little typedef trick that may be hacky or completely fine. This is a learning experience after all.