### PR TITLE
Fixing-merge-sort

### DIFF
--- a/Algorithms.cpp
+++ b/Algorithms.cpp
@@ -8,10 +8,3 @@ void Algorithms::swap(Container & container, int index1, int index2) {
     container.at(index1) = container.at(index2);
     container.at(index2) = temp;
 }
-
-int Algorithms::intMax() {
-    int i = 0;
-    i = ~i;
-    i = (unsigned int) i >> 1;
-    return i;
-}

--- a/Algorithms.h
+++ b/Algorithms.h
@@ -17,14 +17,6 @@ namespace Algorithms {
      */
     template<class Container>
     void swap(Container & container, int index1, int index2);
-
-    /**
-     * @brief   Returns the maximum value for a variable of type int.
-     *          This is done to avoid external libraries (<climits>).
-     * 
-     * @returns int, maximum value for a variable of type int
-     */
-    int intMax();
 }
 
 #endif // !ALGORITHMS_H

--- a/MergeSort.cpp
+++ b/MergeSort.cpp
@@ -29,15 +29,15 @@ void Algorithms::Helper::merge(Container & container, int start, int split, int 
         B[iB] = container[j];
         ++iB;
     }
-    A[sizeA] = intMax();
-    B[sizeB] = intMax();
+    A[sizeA] = std::numeric_limits<T>::max();
+    B[sizeB] = std::numeric_limits<T>::max();
     iA = 0;
     iB = 0;
     for (int j = start; j <= end; ++j) {
-        if (iA < sizeA && A[iA] <= B[iB]) {
+        if (A[iA] <= B[iB]) {
             container[j] = A[iA];
             ++iA;
-        } else if (iB < sizeB) {
+        } else {
             container[j] = B[iB];
             ++iB;
         }

--- a/MergeSort.h
+++ b/MergeSort.h
@@ -1,6 +1,8 @@
 #ifndef MERGESORT_H
 #define MERGESORT_H
 
+#include <limits>
+
 namespace Algorithms
 {
     /**


### PR DESCRIPTION
Fixed the non-integer functionality of merge sort. This creates a dependency on the external library `<limits>`, but it is a standard library. I think I'm being a little too strict at times. The solution does create a limitation (that is beyond the scope for now): the function only works with arithmetic types (see: https://cplusplus.com/reference/limits/numeric_limits/).