### PR TITLE
Heapsort

### DIFF
--- a/Algorithms.cpp
+++ b/Algorithms.cpp
@@ -4,9 +4,9 @@ using namespace Algorithms;
 
 template<class Container>
 void Algorithms::swap(Container & container, int index1, int index2) {
-    auto temp = container.at(index1);
-    container.at(index1) = container.at(index2);
-    container.at(index2) = temp;
+    auto temp = container[index1];
+    container[index1] = container[index2];
+    container[index2] = temp;
 }
 
 template<class Container>

--- a/Algorithms.cpp
+++ b/Algorithms.cpp
@@ -37,8 +37,8 @@ int Algorithms::Heap<Container>::right(int i) { return 2 * i + 2; }
 
 template<class Container>
 bool Algorithms::Heap<Container>::isInHeap(int i) {
-    if (i >= start && i <= end) return true;
-    return false;
+    if (i <= start || i >= start + inHeap) return false;
+    return true;
 }
 
 template<class Container>

--- a/Algorithms.cpp
+++ b/Algorithms.cpp
@@ -8,3 +8,72 @@ void Algorithms::swap(Container & container, int index1, int index2) {
     container.at(index1) = container.at(index2);
     container.at(index2) = temp;
 }
+
+template<class Container>
+Algorithms::Heap<Container>::Heap(Container & container, int first, int last) :
+    container(container), start(first), end(last)
+{
+    length = end - start + 1;
+    inHeap = length;
+}
+
+template<class Container>
+int Algorithms::Heap<Container>::size() { return length; }
+
+// template<class Container>
+// int Algorithms::Heap<Container>::inHeap() { return inHeap; }
+
+template<class Container>
+int Algorithms::Heap<Container>::parent(int i) {
+    if (i <= 0) return 0;
+    return (i - 1) / 2;
+}
+
+template<class Container>
+int Algorithms::Heap<Container>::left(int i) { return 2 * i + 1; }
+
+template<class Container>
+int Algorithms::Heap<Container>::right(int i) { return 2 * i + 2; }
+
+template<class Container>
+bool Algorithms::Heap<Container>::isInHeap(int i) {
+    if (i >= start && i <= end) return true;
+    return false;
+}
+
+template<class Container>
+void Algorithms::Heap<Container>::buildMaxHeap() {
+    inHeap = length;
+    for (int i = start + (length-1)/2; i >= start; --i) fixMaxHeap(i);
+}
+
+template<class Container>
+void Algorithms::Heap<Container>::fixMaxHeap(int i) {
+    int left = this->left(i);
+    int right = this->right(i);
+    int max = i;
+    if (isInHeap(left) && container[left] > container[max]) max = left;
+    if (isInHeap(right) && container[right] > container[max]) max = right;
+    if (max != i) {
+        swap(container, i, max);
+        fixMaxHeap(max);
+    }
+}
+
+template<class Container>
+Container & Algorithms::Heap<Container>::getContainer() { return container; }
+
+template<class Container>
+auto & Algorithms::Heap<Container>::operator[](int i) { return container[i]; }
+
+/*
+template<class Container>
+void Algorithms::buildMaxHeap(Container & container) {
+
+}
+
+template<class Container>
+void Algorithms::fixMaxHeap(Container & container) {
+
+}
+ */

--- a/Algorithms.h
+++ b/Algorithms.h
@@ -27,7 +27,15 @@ namespace Algorithms {
     class Heap
     {
         Container & container;
-        int start, end, length, inHeap;
+        int start, end;
+        /**
+         * The total number of elements in the heap.
+         */
+        int length;
+        /**
+         * The number of elements currently in the heap. Note that inHeap <= length.
+         */
+        int inHeap;
     public:
         /**
          * @brief   Construct a new Heap object.

--- a/Algorithms.h
+++ b/Algorithms.h
@@ -17,6 +17,38 @@ namespace Algorithms {
      */
     template<class Container>
     void swap(Container & container, int index1, int index2);
+
+    /**
+     * @brief   Class to assign a container's index range to a heap structure.
+     * 
+     * @tparam  Container container type
+     */
+    template<class Container>
+    class Heap
+    {
+        Container & container;
+        int start, end, length, inHeap;
+    public:
+        Heap(Container & container, int first, int last);
+        int size();
+        int parent(int i);
+        int left(int i);
+        int right(int i);
+        bool isInHeap(int i);
+        void buildMaxHeap();
+        void fixMaxHeap(int i);
+        Container & getContainer();
+
+        auto & operator[](int i);
+    };
+
+    /*
+    template<class Container>
+    void buildMaxHeap(Container & container);
+
+    template<class Container>
+    void fixMaxHeap(Container & container);
+     */
 }
 
 #endif // !ALGORITHMS_H

--- a/Algorithms.h
+++ b/Algorithms.h
@@ -29,26 +29,74 @@ namespace Algorithms {
         Container & container;
         int start, end, length, inHeap;
     public:
+        /**
+         * @brief   Construct a new Heap object.
+         * 
+         * @param   container holds the data to heapify
+         * @param   first starting index for heap assignment
+         * @param   last last index to use in heap
+         */
         Heap(Container & container, int first, int last);
+        /**
+         * @brief   Get the number of elements in the heap.
+         * 
+         * @returns int, heap size
+         */
         int size();
+        /**
+         * @brief   Get the parent node of the given index.
+         * 
+         * @param   i index whose parent to fetch
+         * @returns int, index of the parent
+         */
         int parent(int i);
+        /**
+         * @brief   Get the left child node of the given index.
+         * 
+         * @param   i index whose left child to fetch
+         * @return  int, index of the left child
+         */
         int left(int i);
+        /**
+         * @brief   Get the right child node of the given index.
+         * 
+         * @param   i index whose right child to fetch
+         * @return  int, index of the right child
+         */
         int right(int i);
+        /**
+         * @brief   Checks if an index is in the heap structure.
+         * 
+         * @param   i index to check
+         * @returns true if index is in heap
+         * @returns false is index is outside of heap
+         */
         bool isInHeap(int i);
+        /**
+         * @brief   Arrange the heap structure into a max heap.
+         *          In a max heap, a node's parent's value is always at least equal to the child's value.
+         */
         void buildMaxHeap();
+        /**
+         * @brief   Fix the max heap property at index i. Checking is done downward (child nodes).
+         * 
+         * @param   i index to start checking downwards from
+         */
         void fixMaxHeap(int i);
+        /**
+         * @brief   Get the underlying Container object by reference.
+         * 
+         * @returns Container& the underlying container
+         */
         Container & getContainer();
-
+        /**
+         * @brief   Get element at index i.
+         * 
+         * @param   i index
+         * @returns auto& element at index i
+         */
         auto & operator[](int i);
     };
-
-    /*
-    template<class Container>
-    void buildMaxHeap(Container & container);
-
-    template<class Container>
-    void fixMaxHeap(Container & container);
-     */
 }
 
 #endif // !ALGORITHMS_H

--- a/Heapsort.cpp
+++ b/Heapsort.cpp
@@ -1,0 +1,15 @@
+#include "Heapsort.h"
+
+using namespace Algorithms;
+
+template<class Container>
+void Algorithms::heapsort(Heap<Container> & heap) {
+    heap.buildMaxHeap();
+    heap.inHeap = heap.length;
+    for (int i = heap.start + heap.length; i > heap.start; --i) {
+        swap(heap, 0, i);
+        --heap.inHeap;
+        heap.fixMaxHeap(0);
+    }
+    heap.inHeap = heap.length;
+}

--- a/Heapsort.h
+++ b/Heapsort.h
@@ -1,0 +1,16 @@
+#ifndef HEAPSORT_H
+#define HEAPSORT_H
+
+namespace Algorithms
+{
+    /**
+     * @brief   Sort data in a heap structure
+     * 
+     * @tparam  Container heap structure's underlying container type
+     * @param   heap data to sort
+     */
+    template<class Container>
+    void heapsort(Heap<Container> & heap);
+}
+
+#endif // !HEAPSORT_H

--- a/Heapsort.h
+++ b/Heapsort.h
@@ -1,6 +1,8 @@
 #ifndef HEAPSORT_H
 #define HEAPSORT_H
 
+#include "Algorithms.h"
+
 namespace Algorithms
 {
     /**


### PR DESCRIPTION
Add heapsorting. This includes a whole class for including heap-related functions on a container. I decided to make it possible to limit the specific index-range assigned to the heap within the underlying container.

This structure (or equivalent functionality) would already be included in the `<algorithm>` standard library, but I felt like doing this myself was important for practising the functionality of this algorithm and the heap structure itself.

Currently, there's no overload for an `at()`-function, as I'd need to dig into template constraining again to keep that safe.