### PR TITLE
Remove namespace ambiguity

### DIFF
--- a/BinarySearch.h
+++ b/BinarySearch.h
@@ -3,6 +3,7 @@
 // #define USE_ITERS 1
 // #define DETACH 1
 
+#include "Algorithms.h"
 /* 
 #if !DETACH
 #include <iterator>

--- a/InsertionSort.h
+++ b/InsertionSort.h
@@ -1,6 +1,8 @@
 #ifndef INSERTIONSORT_H
 #define INSERTIONSORT_H
 
+#include "Algorithms.h"
+
 namespace Algorithms
 {
     /**

--- a/InterpolationSearch.h
+++ b/InterpolationSearch.h
@@ -1,6 +1,8 @@
 #ifndef INTERPOLATIONSEARCH_H
 #define INTERPOLATIONSEARCH_H
 
+#include "Algorithms.h"
+
 namespace Algorithms
 {
     /**

--- a/LinearSearch.h
+++ b/LinearSearch.h
@@ -1,8 +1,7 @@
 #ifndef LINEARSEARCH_H
 #define LINEARSEARCH_H
 
-// #include "Algorithms.h"
-// #include <vector>
+#include "Algorithms.h"
 
 namespace Algorithms
 {

--- a/MergeSort.h
+++ b/MergeSort.h
@@ -1,6 +1,7 @@
 #ifndef MERGESORT_H
 #define MERGESORT_H
 
+#include "Algorithms.h"
 #include <limits>
 
 namespace Algorithms

--- a/SelectionSort.h
+++ b/SelectionSort.h
@@ -1,6 +1,8 @@
 #ifndef SELECTIONSORT_H
 #define SELECTIONSORT_H
 
+#include "Algorithms.h"
+
 namespace Algorithms
 {
     /**


### PR DESCRIPTION
Investigating the reason why heapsort can access the private members of the Heap class led me to learn more about namespace definition. The previous detached implementation ran a risk of causing undefined behaviour as each independent header file essentially re-declared the `Algorithms` namespace. This didn't cause any issues thus far but is bad practice. All headers that use the namespace now `#include` `Algorithms.h`, which ensures that it alone declares the namespace.